### PR TITLE
Added support for src port iteration

### DIFF
--- a/include/dublintraceroute/dublin_traceroute.h
+++ b/include/dublintraceroute/dublin_traceroute.h
@@ -49,7 +49,7 @@ private:
 				 max_ttl_;
 	const uint16_t		 delay_;
 	const bool		 broken_nat_,
-					iterate_sport_;
+				 use_srcport_for_path_generation_;
 	std::mutex		 mutex_tracerouting,
 				 mutex_sniffed_packets;
 	IPv4Address		 my_address;
@@ -64,7 +64,7 @@ public:
 	static const uint8_t	 default_max_ttl = 30;
 	static const uint16_t	 default_delay = 10;
 	static const bool	 default_broken_nat = false;
-	static const bool	 default_iterate_sport = false;
+	static const bool	 default_use_srcport_for_path_generation = false;
 	DublinTraceroute(
 			const std::string &dst,
 			const uint16_t srcport = default_srcport,
@@ -74,7 +74,7 @@ public:
 			const uint8_t max_ttl = default_max_ttl,
 			const uint16_t delay = default_delay,
 			const bool broken_nat = default_broken_nat,
-			const bool iterate_sport = default_iterate_sport
+			const bool use_srcport_for_path_generation = default_use_srcport_for_path_generation
 			):
 				srcport_(srcport),
 				dstport_(dstport),
@@ -84,7 +84,7 @@ public:
 				max_ttl_(max_ttl),
 				delay_(delay),
 				broken_nat_(broken_nat),
-				iterate_sport_(iterate_sport)
+				use_srcport_for_path_generation_(use_srcport_for_path_generation)
 	{ validate_arguments(); }
 	DublinTraceroute(
 			const char *dst,
@@ -95,7 +95,7 @@ public:
 			const uint8_t max_ttl = default_max_ttl,
 			const uint16_t delay = default_delay,
 			const bool broken_nat = default_broken_nat,
-			const bool iterate_sport = default_iterate_sport
+			const bool use_srcport_for_path_generation = default_use_srcport_for_path_generation
 		       ):
 				srcport_(srcport),
 				dstport_(dstport),
@@ -105,7 +105,7 @@ public:
 				max_ttl_(max_ttl),
 				delay_(delay),
 				broken_nat_(broken_nat),
-				iterate_sport_(iterate_sport)
+				use_srcport_for_path_generation_(use_srcport_for_path_generation)
 	{ validate_arguments(); }
 	~DublinTraceroute() { std::lock_guard<std::mutex> lock(mutex_tracerouting); };
 	DublinTraceroute(const DublinTraceroute& source):
@@ -117,7 +117,7 @@ public:
 		max_ttl_(source.max_ttl_),
 		delay_(source.delay_),
 		broken_nat_(source.broken_nat_),
-		iterate_sport_(source.iterate_sport_)
+		use_srcport_for_path_generation_(source.use_srcport_for_path_generation_)
 	{ validate_arguments(); }
 
 	inline const uint16_t srcport() const { return srcport_; }
@@ -127,7 +127,7 @@ public:
 	inline const uint8_t max_ttl() const { return max_ttl_; }
 	inline const uint16_t delay() const { return delay_; }
 	inline const bool broken_nat() const { return broken_nat_; }
-	inline const bool iterate_sport() const { return iterate_sport_; }
+	inline const bool use_srcport_for_path_generation() const { return use_srcport_for_path_generation_; }
 	inline const std::string &dst() const { return dst_; }
 	inline const IPv4Address &target() const { return target_; }
 	void target(const IPv4Address &addr) { target_ = addr; }

--- a/include/dublintraceroute/dublin_traceroute.h
+++ b/include/dublintraceroute/dublin_traceroute.h
@@ -48,7 +48,8 @@ private:
 				 min_ttl_,
 				 max_ttl_;
 	const uint16_t		 delay_;
-	const bool		 broken_nat_;
+	const bool		 broken_nat_,
+					iterate_sport_;
 	std::mutex		 mutex_tracerouting,
 				 mutex_sniffed_packets;
 	IPv4Address		 my_address;
@@ -63,6 +64,7 @@ public:
 	static const uint8_t	 default_max_ttl = 30;
 	static const uint16_t	 default_delay = 10;
 	static const bool	 default_broken_nat = false;
+	static const bool	 default_iterate_sport = false;
 	DublinTraceroute(
 			const std::string &dst,
 			const uint16_t srcport = default_srcport,
@@ -71,7 +73,8 @@ public:
 			const uint8_t min_ttl = default_min_ttl,
 			const uint8_t max_ttl = default_max_ttl,
 			const uint16_t delay = default_delay,
-			const bool broken_nat = default_broken_nat
+			const bool broken_nat = default_broken_nat,
+			const bool iterate_sport = default_iterate_sport
 			):
 				srcport_(srcport),
 				dstport_(dstport),
@@ -80,7 +83,8 @@ public:
 				min_ttl_(min_ttl),
 				max_ttl_(max_ttl),
 				delay_(delay),
-				broken_nat_(broken_nat)
+				broken_nat_(broken_nat),
+				iterate_sport_(iterate_sport)
 	{ validate_arguments(); }
 	DublinTraceroute(
 			const char *dst,
@@ -90,7 +94,8 @@ public:
 			const uint8_t min_ttl = default_min_ttl,
 			const uint8_t max_ttl = default_max_ttl,
 			const uint16_t delay = default_delay,
-			const bool broken_nat = default_broken_nat
+			const bool broken_nat = default_broken_nat,
+			const bool iterate_sport = default_iterate_sport
 		       ):
 				srcport_(srcport),
 				dstport_(dstport),
@@ -99,7 +104,8 @@ public:
 				min_ttl_(min_ttl),
 				max_ttl_(max_ttl),
 				delay_(delay),
-				broken_nat_(broken_nat)
+				broken_nat_(broken_nat),
+				iterate_sport_(iterate_sport)
 	{ validate_arguments(); }
 	~DublinTraceroute() { std::lock_guard<std::mutex> lock(mutex_tracerouting); };
 	DublinTraceroute(const DublinTraceroute& source):
@@ -110,7 +116,8 @@ public:
 		min_ttl_(source.min_ttl_),
 		max_ttl_(source.max_ttl_),
 		delay_(source.delay_),
-		broken_nat_(source.broken_nat_)
+		broken_nat_(source.broken_nat_),
+		iterate_sport_(source.iterate_sport_)
 	{ validate_arguments(); }
 
 	inline const uint16_t srcport() const { return srcport_; }
@@ -120,6 +127,7 @@ public:
 	inline const uint8_t max_ttl() const { return max_ttl_; }
 	inline const uint16_t delay() const { return delay_; }
 	inline const bool broken_nat() const { return broken_nat_; }
+	inline const bool iterate_sport() const { return iterate_sport_; }
 	inline const std::string &dst() const { return dst_; }
 	inline const IPv4Address &target() const { return target_; }
 	void target(const IPv4Address &addr) { target_ = addr; }

--- a/include/dublintraceroute/traceroute_results.h
+++ b/include/dublintraceroute/traceroute_results.h
@@ -30,10 +30,10 @@ private:
 	uint8_t min_ttl = 1;
 	bool compressed_;
 	bool broken_nat_;
-	bool iterate_sport_;
+	bool use_srcport_for_path_generation_;
 
 public:
-	TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl /* = 1 */, const bool broken_nat /* = false */, const bool iterate_sport /* = false */);
+	TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl /* = 1 */, const bool broken_nat /* = false */, const bool use_srcport_for_path_generation /* = false */);
 	~TracerouteResults() { };
 	inline flow_map_t &flows() { return *flows_; }
 	std::shared_ptr<IP> match_packet(const Packet &packet);

--- a/include/dublintraceroute/traceroute_results.h
+++ b/include/dublintraceroute/traceroute_results.h
@@ -30,9 +30,10 @@ private:
 	uint8_t min_ttl = 1;
 	bool compressed_;
 	bool broken_nat_;
+	bool iterate_sport_;
 
 public:
-	TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl /* = 1 */, const bool broken_nat /* = false */);
+	TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl /* = 1 */, const bool broken_nat /* = false */, const bool iterate_sport /* = false */);
 	~TracerouteResults() { };
 	inline flow_map_t &flows() { return *flows_; }
 	std::shared_ptr<IP> match_packet(const Packet &packet);

--- a/src/dublin_traceroute.cc
+++ b/src/dublin_traceroute.cc
@@ -191,7 +191,7 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 	std::shared_ptr<flow_map_t> flows(new flow_map_t);
 
 	uint16_t iterated_port = dstport();
-	if(iterate_sport()) iterated_port = srcport();
+	if(use_srcport_for_path_generation()) iterated_port = srcport();
 	uint16_t end_port = iterated_port + npaths();
 
 	// forge the packets to send
@@ -217,7 +217,7 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 		 	 */
 			
 			UDPv4Probe *probe = NULL;
-			if(iterate_sport()){
+			if(use_srcport_for_path_generation()){
 				probe = new UDPv4Probe(target(), dstport(), iterated_port, ttl);
 			}
 			else{
@@ -244,7 +244,7 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 
 	listener_thread.join();
 
-	TracerouteResults *results = new TracerouteResults(flows, min_ttl_, broken_nat(), iterate_sport());
+	TracerouteResults *results = new TracerouteResults(flows, min_ttl_, broken_nat(), use_srcport_for_path_generation());
 
 	match_sniffed_packets(*results);
 	match_hostnames(*results, flows);

--- a/src/main.cc
+++ b/src/main.cc
@@ -63,7 +63,7 @@ Options:
   -T MAX_TTL --max-ttl=MAX_TTL  the maximum TTL to probe. Must be greater or equal than the minimum TTL (default: )" << static_cast<int>(DublinTraceroute::default_max_ttl) << R"()
   -D DELAY --delay=DELAY        the inter-packet delay in milliseconds (default: )" << DublinTraceroute::default_delay << R"()
   -b --broken-nat               the network has a broken NAT configuration (e.g. no payload fixup). Try this if you see less hops than expected
-  -i --use-srcport            generate paths using source port instead of destination port
+  -i --use-srcport              generate paths using source port instead of destination port
   -o --output-file              the output file name (default: )" << DEFAULT_OUTPUT_FILE << R"()
 
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -30,7 +30,7 @@ const struct option longopts[] = {
 	{"max-ttl", required_argument, NULL, 'T'},
 	{"delay", required_argument, NULL, 'D'},
 	{"broken-nat", no_argument, NULL, 'b'},
-	{"iterate-sport", no_argument, NULL, 'i'},
+	{"use-srcport", no_argument, NULL, 'i'},
 	{"output-file", required_argument, NULL, 'o'},
 	{NULL, 0, NULL, 0},
 };
@@ -41,14 +41,14 @@ static void usage() {
 R"(Written by Andrea Barberio - https://insomniac.slackware.it
 
 Usage:
-  dublin-traceroute <target> [--sport=SRC_PORT]
+  dublin-traceroute <target> [--sport=src_base_port]
                              [--dport=dest_base_port]
                              [--npaths=num_paths]
                              [--min-ttl=min_ttl]
                              [--max-ttl=max_ttl]
                              [--delay=delay_in_ms]
                              [--broken-nat]
-							 [--iterate-sport]
+                             [--use-srcport]
                              [--output-file=file_name]
                              [--help]
                              [--version]
@@ -63,7 +63,7 @@ Options:
   -T MAX_TTL --max-ttl=MAX_TTL  the maximum TTL to probe. Must be greater or equal than the minimum TTL (default: )" << static_cast<int>(DublinTraceroute::default_max_ttl) << R"()
   -D DELAY --delay=DELAY        the inter-packet delay in milliseconds (default: )" << DublinTraceroute::default_delay << R"()
   -b --broken-nat               the network has a broken NAT configuration (e.g. no payload fixup). Try this if you see less hops than expected
-  -i --iterate-sport            iterate the source port instead of the destination port
+  -i --use-srcport            generate paths using source port instead of destination port
   -o --output-file              the output file name (default: )" << DEFAULT_OUTPUT_FILE << R"()
 
 
@@ -84,7 +84,7 @@ main(int argc, char **argv) {
 	long	max_ttl = DublinTraceroute::default_max_ttl;
 	long	delay = DublinTraceroute::default_delay;
 	bool	broken_nat = DublinTraceroute::default_broken_nat;
-	bool	iterate_sport = DublinTraceroute::default_iterate_sport;
+	bool	use_srcport_for_path_generation = DublinTraceroute::default_use_srcport_for_path_generation;
 	std::string	output_file = DEFAULT_OUTPUT_FILE;
 
 	if (geteuid() == 0) {
@@ -134,7 +134,7 @@ main(int argc, char **argv) {
 				broken_nat = true;
 				break;
 			case 'i':
-				iterate_sport = true;
+				use_srcport_for_path_generation = true;
 				break;
 			case 'o':
 				output_file.assign(optarg);
@@ -200,16 +200,16 @@ main(int argc, char **argv) {
 			max_ttl,
 			delay,
 			broken_nat,
-			iterate_sport
+			use_srcport_for_path_generation
 	);
 	
 	std::cout << "Traceroute from 0.0.0.0:" << Dublin.srcport();
-	if(iterate_sport == 1){
+	if(use_srcport_for_path_generation == 1){
 		std::cout << "~" << (Dublin.srcport() + npaths - 1);
 	}
 	
 	std::cout << " to " << Dublin.dst() << ":" << Dublin.dstport();
-	if(iterate_sport == 0){
+	if(use_srcport_for_path_generation == 0){
 		std::cout << "~" << (Dublin.dstport() + npaths - 1);
 	}
 	

--- a/src/traceroute_results.cc
+++ b/src/traceroute_results.cc
@@ -21,8 +21,8 @@
 #include "dublintraceroute/icmp_messages.h"
 
 
-TracerouteResults::TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl = 1, const bool broken_nat = true, const bool iterate_sport = true):
-		flows_(flows), min_ttl(min_ttl), compressed_(false), broken_nat_(broken_nat), iterate_sport_(iterate_sport) {
+TracerouteResults::TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl = 1, const bool broken_nat = true, const bool use_srcport_for_path_generation = true):
+		flows_(flows), min_ttl(min_ttl), compressed_(false), broken_nat_(broken_nat), use_srcport_for_path_generation_(use_srcport_for_path_generation) {
 }
 
 
@@ -64,10 +64,10 @@ std::shared_ptr<IP> TracerouteResults::match_packet(const Packet &packet) {
 	}
 
 	// Try to match the received packet against the sent packets. The flow
-	// is identified by the UDP destination port in the case of iterate_sport is set to false
-	// if iterate_sport is set to true the source port is used to identify the flow
+	// is identified by the UDP destination port in the case of use_srcport_for_path_generation is set to false
+	// if use_srcport_for_path_generation is set to true the source port is used to identify the flow
 	auto flow_id = inner_udp.dport();
-	if(iterate_sport_){
+	if(use_srcport_for_path_generation_){
 		flow_id = inner_udp.sport();
 	}
 

--- a/src/traceroute_results.cc
+++ b/src/traceroute_results.cc
@@ -21,8 +21,8 @@
 #include "dublintraceroute/icmp_messages.h"
 
 
-TracerouteResults::TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl = 1, const bool broken_nat = true):
-		flows_(flows), min_ttl(min_ttl), compressed_(false), broken_nat_(broken_nat) {
+TracerouteResults::TracerouteResults(std::shared_ptr<flow_map_t> flows, const uint8_t min_ttl = 1, const bool broken_nat = true, const bool iterate_sport = true):
+		flows_(flows), min_ttl(min_ttl), compressed_(false), broken_nat_(broken_nat), iterate_sport_(iterate_sport) {
 }
 
 
@@ -64,8 +64,13 @@ std::shared_ptr<IP> TracerouteResults::match_packet(const Packet &packet) {
 	}
 
 	// Try to match the received packet against the sent packets. The flow
-	// is identified by the UDP destination port
+	// is identified by the UDP destination port in the case of iterate_sport is set to false
+	// if iterate_sport is set to true the source port is used to identify the flow
 	auto flow_id = inner_udp.dport();
+	if(iterate_sport_){
+		flow_id = inner_udp.sport();
+	}
+
 	std::shared_ptr<Hops> hops;
 	try {
 		hops = flows().at(flow_id);


### PR DESCRIPTION
Hi,

This patch adds a new parameter (-i or --iterate-sport) to allow the iteration of the src ports instead of the destination port. I did run the test, and all seems ok! Not sure if I'm following the correct coding conventions so if the request need any modification just let me know!

Regards,