### PR TITLE
Default to stdout for traceroute's JSON output

### DIFF
--- a/include/dublintraceroute/traceroute_results.h
+++ b/include/dublintraceroute/traceroute_results.h
@@ -37,7 +37,7 @@ public:
 	~TracerouteResults() { };
 	inline flow_map_t &flows() { return *flows_; }
 	std::shared_ptr<IP> match_packet(const Packet &packet);
-	void show(std::ostream &stream=std::cout);
+	void show(std::ostream &stream=std::cerr);
 	void compress();
 	std::string to_json();
 };


### PR DESCRIPTION
Now the JSON output is by default on stdout, and any other output goes
to stderr, making it easier to feed the JSON data to other programs,
e.g. jq .

Fixes #80

Signed-off-by: Andrea Barberio <insomniac@slackware.it>