### PR TITLE
Initial support for probe type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project (dublin-traceroute)
 
 # TODO sync this with VERSION in include/dublintraceroute/common.h
 set (dublin-traceroute_VERSION_MAJOR_0)
-set (dublin-traceroute_VERSION_MINOR_4)
-set (dublin-traceroute_VERSION_PATCH_2)
+set (dublin-traceroute_VERSION_MINOR_5)
+set (dublin-traceroute_VERSION_PATCH_0)
 
 # ensure that /usr/local is used to find dependencies. This is especially
 # necessary for brew on OSX and for libraries installed manually under
@@ -26,7 +26,7 @@ add_library(dublintraceroute SHARED
 # Set the shared library version
 set_target_properties(dublintraceroute
     PROPERTIES
-      SOVERSION 0.1.1
+      SOVERSION 0.2.0
     )
 
 find_package(PkgConfig)

--- a/include/dublintraceroute/common.h
+++ b/include/dublintraceroute/common.h
@@ -16,7 +16,7 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 
-#define VERSION	"0.4.2"
+#define VERSION	"0.5.0"
 
 #include <map>
 

--- a/src/dublin_traceroute.cc
+++ b/src/dublin_traceroute.cc
@@ -93,6 +93,10 @@ const void DublinTraceroute::validate_arguments() {
 		throw std::invalid_argument(
 			"delay must be between 0 and 1000 milliseconds");
 	}
+	if (type_ <= probe_type::min || type_ >= probe_type::max) {
+		throw std::invalid_argument(
+			"invalid probe type");
+	}
 }
 
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,6 +77,7 @@ Additional features in the Python module at https://github.com/insomniacslk/pyth
 int
 main(int argc, char **argv) {
 	std::string	target;
+	probe_type type = DublinTraceroute::default_type;
 	long	sport = DublinTraceroute::default_srcport;
 	long	dport = DublinTraceroute::default_dstport;
 	long	npaths = DublinTraceroute::default_npaths;
@@ -200,10 +201,11 @@ main(int argc, char **argv) {
 		std::exit(EXIT_FAILURE);
 	}
 
-	std::cerr << "Starting dublin-traceroute" << std::endl;
+	std::cerr << "Starting dublin-traceroute (probe type: " << probe_type_name(type) << ")" << std::endl;
 
 	DublinTraceroute Dublin(
 			target,
+			type,
 			sport,
 			dport,
 			npaths,


### PR DESCRIPTION
This will enable further development of multiple types of probes in the C++ library.

Also bumped version to 0.5.0 since this is a breaking change.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>