### PR TITLE
Fix constructor

### DIFF
--- a/include/dublintraceroute/dublin_traceroute.h
+++ b/include/dublintraceroute/dublin_traceroute.h
@@ -127,7 +127,7 @@ public:
 			const bool no_dns = default_no_dns
 		       ):
 				dst_(std::string(dst)),
-				type_(type_),
+				type_(type),
 				srcport_(srcport),
 				dstport_(dstport),
 				npaths_(npaths),


### PR DESCRIPTION
In the previous commit I broke a constructor using the wrong variable
name.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>