### PR TITLE
[go] replace ipv6/ipv6 network library with golang.org/x/net

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,7 +1,7 @@
 name: coverity-scan
 on:
   schedule:
-    - cron: '30 4 0 * *' # Every Sunday at 4:30 UTC
+    - cron: '30 4 * * 0' # Every Sunday at 4:30 UTC
 
 jobs:
   latest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,28 +51,41 @@ jobs:
     strategy:
       matrix:
         go: ['1.14', '1.15']
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'macos-latest'] # , 'windows-latest']
     steps:
       - uses: actions/checkout@v2
         with:
           # clone in the gopath
           path: src/github.com/${{ github.repository }}
+      - if: github.event_name == 'pull_request'
+        # this is for debugging. pull_request has a different hash from push,
+        # but the original hash is exposed in github.event.pull_request.head.sha
+        run: |
+          echo "Building SHA ${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
           stable: false
           go-version: ${{ matrix.go }}
       - run: |
           echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - run: |
-          cd $GITHUB_WORKSPACE/src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/dublin-traceroute
+      - if: matrix.os != 'windows-latest'
+        run: |
+          cd src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/dublin-traceroute
           go get -v ./...
           go build
           ./dublin-traceroute --version
+      - if: matrix.os == 'windows-latest'
+        run: |
+          cd src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/dublin-traceroute
+          go get -v ./...
+          go build
+          .\dublin-traceroute.exe --version
   test_go:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go: ['1.14', '1.15']
+        os: ['ubuntu-latest', 'macos-latest'] # , 'windows-latest']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -84,8 +97,9 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: |
           echo "GOPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - run: |
-          cd $GITHUB_WORKSPACE/src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/dublin-traceroute
+      - if: matrix.os != 'windows-latest'
+        run: |
+          cd src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/dublin-traceroute
           go get -v -t ./...
           echo "" > coverage.txt
           for d in $(go list ./...); do
@@ -129,11 +143,22 @@ jobs:
       - uses: actions/checkout@v2
         with:
           # clone in the gopath
-          path: src/github.com/${{ github.repository }}
+          path: "src/github.com/${{ github.repository }}"
+      - if: github.event_name == 'pull_request'
+        # this is for debugging. pull_request has a different hash from push,
+        # but the original hash is exposed in github.event.pull_request.head.sha
+        run: |
+          echo "Building SHA ${{ github.event.pull_request.head.sha }}"
       - uses: actions/setup-go@v2
         with:
           stable: false
           go-version: ${{ matrix.go }}
+      - name: build routest
+        run: |
+          set -exu
+          cd "src/github.com/${{ github.repository }}/go/dublintraceroute/cmd/routest"
+          go get -v ./...
+          go build
       - name: Login to Docker hub
         run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - name: Build docker image

--- a/go/dublintraceroute/cmd/routest/main.go
+++ b/go/dublintraceroute/cmd/routest/main.go
@@ -94,7 +94,7 @@ func main() {
 	fn := func(a nfqueue.Attribute) (ret int) {
 		// TODO IPv6
 		verdict := nfqueue.NfDrop
-		reply, err := forgeReplyv4(cfg, *a.Payload)
+		header, payload, err := forgeReplyv4(cfg, *a.Payload)
 		if err != nil {
 			if err == ErrNoMatch {
 				log.Infof("Packet not matching")
@@ -106,7 +106,7 @@ func main() {
 			}
 			goto end
 		}
-		if err := Send4(*flagIfname, reply); err != nil {
+		if err := Send4(*flagIfname, header, payload); err != nil {
 			log.Warningf("send4 failed: %v", err)
 			goto end
 		}

--- a/go/dublintraceroute/cmd/routest/send.go
+++ b/go/dublintraceroute/cmd/routest/send.go
@@ -6,16 +6,17 @@ import (
 	"net"
 	"syscall"
 
-	inet "github.com/insomniacslk/dublin-traceroute/go/dublintraceroute/net"
+	"golang.org/x/net/ipv4"
 	"golang.org/x/sys/unix"
 )
 
 // Send4 sends an IPv4 packet to its destination.
-func Send4(ifname string, ip *inet.IPv4) error {
-	data, err := ip.MarshalBinary()
+func Send4(ifname string, ip *ipv4.Header, payload []byte) error {
+	h, err := ip.Marshal()
 	if err != nil {
 		return err
 	}
+	data := append(h, payload...)
 	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_RAW, syscall.IPPROTO_RAW)
 	if err != nil {
 		return err

--- a/go/dublintraceroute/net/icmpv6.go
+++ b/go/dublintraceroute/net/icmpv6.go
@@ -114,7 +114,7 @@ func (i ICMPv6) MarshalBinary() ([]byte, error) {
 	binary.Write(&bc, binary.BigEndian, i.Type)
 	binary.Write(&bc, binary.BigEndian, i.Code)
 	binary.Write(&bc, binary.BigEndian, payload)
-	i.Checksum = checksum(bc.Bytes())
+	i.Checksum = Checksum(bc.Bytes())
 	binary.Write(&b, binary.BigEndian, i.Checksum)
 	binary.Write(&b, binary.BigEndian, i.Unused)
 	return b.Bytes(), nil

--- a/go/dublintraceroute/net/ipv4.go
+++ b/go/dublintraceroute/net/ipv4.go
@@ -2,6 +2,7 @@
 
 package net
 
+/*
 import (
 	"bytes"
 	"encoding/binary"
@@ -137,14 +138,14 @@ func (h IPv4) MarshalBinary() ([]byte, error) {
 	if h.Proto < 0 || h.Proto > 0xff {
 		return nil, errors.New("invalid protocol")
 	}
-	if h.Proto == 0 {
-		switch next.(type) {
-		case *UDP:
-			h.Proto = ProtoUDP
-		case *ICMP:
-			h.Proto = ProtoICMP
+		if h.Proto == 0 {
+			switch next.(type) {
+			case *UDP:
+				h.Proto = ProtoUDP
+			case *ICMP:
+				h.Proto = ProtoICMP
+			}
 		}
-	}
 	binary.Write(&b, binary.BigEndian, uint8(h.Proto))
 
 	// Checksum - left to 0, filled in by the platform
@@ -228,11 +229,11 @@ func (h *IPv4) UnmarshalBinary(b []byte) error {
 	}
 	payload := b[h.HeaderLen*4 : h.TotalLen]
 	if h.Proto == ProtoUDP && !h.IsFragment() {
-		u, err := NewUDP(payload)
-		if err != nil {
-			return err
-		}
-		h.next = u
+			u, err := NewUDP(payload)
+			if err != nil {
+				return err
+			}
+				h.next = u
 	} else if h.Proto == ProtoICMP {
 		i, err := NewICMP(payload)
 		if err != nil {
@@ -245,3 +246,4 @@ func (h *IPv4) UnmarshalBinary(b []byte) error {
 
 	return nil
 }
+*/

--- a/go/dublintraceroute/net/ipv6.go
+++ b/go/dublintraceroute/net/ipv6.go
@@ -88,14 +88,16 @@ func (h IPv6) MarshalBinary() ([]byte, error) {
 	if h.NextHeader < 0 || h.NextHeader > 0xff {
 		return nil, errors.New("invalid IPv6 next header")
 	}
-	if h.NextHeader == 0 {
-		switch h.next.(type) {
-		case *UDP:
-			h.NextHeader = ProtoUDP
-		case *ICMPv6:
-			h.NextHeader = ProtoICMPv6
+	/*
+		if h.NextHeader == 0 {
+			switch h.next.(type) {
+			case *UDP:
+				h.NextHeader = ProtoUDP
+			case *ICMPv6:
+				h.NextHeader = ProtoICMPv6
+			}
 		}
-	}
+	*/
 	// hop limit
 	if h.HopLimit < 0 || h.HopLimit > 0xff {
 		return nil, errors.New("invalid IPv6 hop limit")
@@ -152,11 +154,13 @@ func (h *IPv6) UnmarshalBinary(b []byte) error {
 	}
 	payload := b[IPv6HeaderLen : IPv6HeaderLen+h.PayloadLen]
 	if h.NextHeader == ProtoUDP {
-		u, err := NewUDP(payload)
-		if err != nil {
-			return err
-		}
-		h.next = u
+		/*
+			u, err := NewUDP(payload)
+			if err != nil {
+				return err
+			}
+			h.next = u
+		*/
 	} else {
 		h.next = &Raw{Data: payload}
 	}

--- a/go/dublintraceroute/net/localaddr.go
+++ b/go/dublintraceroute/net/localaddr.go
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+package net
+
+import "net"
+
+// GetLocalAddr returns the local address to reach the IP address with the given network type.
+func GetLocalAddr(network string, ip net.IP) (net.Addr, error) {
+	// ugly porkaround until I find how to get the local address in a better
+	// way. A port different from 0 is required on darwin, so using udp/53.
+	conn, err := net.Dial(network, net.JoinHostPort(ip.String(), "53"))
+	if err != nil {
+		return nil, err
+	}
+	localAddr := conn.LocalAddr()
+	_ = conn.Close()
+	return localAddr, nil
+}

--- a/go/dublintraceroute/probes/probev4/udpv4probe.go
+++ b/go/dublintraceroute/probes/probev4/udpv4probe.go
@@ -4,17 +4,21 @@ package probev4
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"time"
 
 	inet "github.com/insomniacslk/dublin-traceroute/go/dublintraceroute/net"
 	"github.com/insomniacslk/dublin-traceroute/go/dublintraceroute/probes"
+	"golang.org/x/net/ipv4"
 )
 
 // ProbeUDPv4 represents a sent probe packet with its metadata
 type ProbeUDPv4 struct {
-	Data []byte
-	ip   *inet.IPv4
+	Data    []byte
+	ip      *ipv4.Header
+	udp     *inet.UDP
+	payload []byte
 	// time the packet is sent at
 	Timestamp time.Time
 	// local address of the packet sender
@@ -25,110 +29,110 @@ type ProbeUDPv4 struct {
 func (p *ProbeUDPv4) Validate() error {
 	if p.ip == nil {
 		// decode packet
-		ip, err := inet.NewIPv4(p.Data)
+		hdr, err := ipv4.ParseHeader(p.Data)
 		if err != nil {
 			return err
 		}
-		p.ip = ip
+		p.ip = hdr
 	}
-	l := p.ip.Next()
-	if l == nil {
+	if p.ip.Protocol != int(inet.ProtoUDP) {
+		return fmt.Errorf("IP payload is not UDP, expected type %d, got %d", inet.ProtoUDP, p.ip.Protocol)
+	}
+	p.payload = p.Data[p.ip.Len:]
+	if len(p.payload) == 0 {
 		return errors.New("IP layer has no payload")
 	}
-	if _, ok := l.(*inet.UDP); !ok {
-		return errors.New("no UDP layer")
+	udp, err := inet.NewUDP(p.Data[p.ip.Len:])
+	if err != nil {
+		return fmt.Errorf("failed to parse UDP header: %w", err)
 	}
+	p.udp = udp
+	p.payload = p.Data[p.ip.Len+inet.UDPHeaderLen:]
 	return nil
 }
 
-// IP returns the IP layer of the probe. If not decoded yet, will return nil.
-func (p ProbeUDPv4) IP() *inet.IPv4 {
+// IP returns the IP header of the probe. If not decoded yet, will return nil.
+func (p ProbeUDPv4) IP() *ipv4.Header {
 	return p.ip
 }
 
-// UDP returns the UDP layer of the probe. If not decoded yet, will return nil.
+// UDP returns the payload of the IP header of the probe. If not decoded yet,
+// will return nil.
 func (p ProbeUDPv4) UDP() *inet.UDP {
-	if p.ip == nil {
-		return nil
-	}
-	u, ok := p.ip.Next().(*inet.UDP)
-	if !ok {
-		return nil
-	}
-	return u
+	return p.udp
 }
 
 // ProbeResponseUDPv4 represents a received probe response with its metadata
 type ProbeResponseUDPv4 struct {
-	Data    []byte
-	icmp    *inet.ICMP
-	innerIP *inet.IPv4
+	// header, payload and timestamp are expected to be passed at object creation
+	Header *ipv4.Header
+	// the IPv4 payload (expected ICMP -> IP -> UDP)
+	Payload []byte
+	// Addr is the IP address of the response sender
+	Addr net.IP
 	// time the packet is received at
 	Timestamp time.Time
-	// sender IP address
-	Addr net.IP
+
+	// the following are computed, internal fields instead
+	icmp         *inet.ICMP
+	innerIP      *ipv4.Header
+	innerUDP     *inet.UDP
+	innerPayload []byte
 }
 
 // Validate verifies that the probe response has the expected structure, and returns an error if not
 func (pr *ProbeResponseUDPv4) Validate() error {
 	if pr.icmp == nil {
 		// decode packet
-		icmp, err := inet.NewICMP(pr.Data)
+		icmp, err := inet.NewICMP(pr.Payload)
 		if err != nil {
 			return err
 		}
 		pr.icmp = icmp
 	}
-	var l inet.Layer
-	if l = pr.icmp.Next(); l == nil {
+	if len(pr.icmp.Payload) == 0 {
 		return errors.New("ICMP layer has no payload")
 	}
-	raw, ok := l.(*inet.Raw)
-	if !ok {
-		return errors.New("no payload in ICMP layer")
+	ip, err := ipv4.ParseHeader(pr.icmp.Payload)
+	if err != nil {
+		return fmt.Errorf("failed to parse inner IPv4 header: %w", err)
 	}
-	var ip inet.IPv4
-	ip.IPinICMP = true
-	if err := ip.UnmarshalBinary(raw.Data); err != nil {
-		return err
-	}
-	pr.innerIP = &ip
-	l = pr.innerIP.Next()
-	if l == nil {
+	pr.innerIP = ip
+	payload := pr.icmp.Payload[ip.Len:]
+	if len(payload) == 0 {
 		return errors.New("inner IP layer has no payload")
 	}
-	if _, ok := l.(*inet.UDP); !ok {
-		return errors.New("inner IP layer has no UDP layer")
+	if ip.Protocol != int(inet.ProtoUDP) {
+		return fmt.Errorf("inner IP payload is not UDP, want protocol %d, got %d", inet.ProtoUDP, ip.Protocol)
 	}
+	udp, err := inet.NewUDP(payload)
+	if err != nil {
+		return fmt.Errorf("failed to decode inner UDP header: %w", err)
+	}
+	pr.innerUDP = udp
+	pr.innerPayload = payload[inet.UDPHeaderLen:]
 	return nil
 }
 
 // ICMP returns the ICMP layer of the probe response. If not decoded yet, will return nil.
-func (pr ProbeResponseUDPv4) ICMP() *inet.ICMP {
+func (pr *ProbeResponseUDPv4) ICMP() *inet.ICMP {
 	return pr.icmp
 }
 
 // InnerIP returns the inner IP layer of the probe response. If not decoded yet, will return nil.
-func (pr ProbeResponseUDPv4) InnerIP() *inet.IPv4 {
+func (pr *ProbeResponseUDPv4) InnerIP() *ipv4.Header {
 	return pr.innerIP
 }
 
 // InnerUDP returns the UDP layer of the probe. If not decoded yet, will return nil.
-func (pr ProbeResponseUDPv4) InnerUDP() *inet.UDP {
-	if pr.innerIP == nil {
-		return nil
-	}
-	u, ok := pr.innerIP.Next().(*inet.UDP)
-	if !ok {
-		return nil
-	}
-	return u
+func (pr *ProbeResponseUDPv4) InnerUDP() *inet.UDP {
+	return pr.innerUDP
 }
 
 // Matches returns true if this probe response matches the given probe. Both
 // probes must have been already validated with Validate, this function may
 // panic otherwise.
-func (pr ProbeResponseUDPv4) Matches(pi probes.Probe) bool {
+func (pr *ProbeResponseUDPv4) Matches(pi probes.Probe) bool {
 	p := pi.(*ProbeUDPv4)
 	if p == nil {
 		return false
@@ -137,14 +141,14 @@ func (pr ProbeResponseUDPv4) Matches(pi probes.Probe) bool {
 		// we want time-exceeded or port-unreachable
 		return false
 	}
-	if !pr.InnerIP().Dst.To4().Equal(p.IP().Dst.To4()) {
+	if !pr.InnerIP().Dst.To4().Equal(p.ip.Dst.To4()) {
 		return false
 	}
 	if p.UDP().Src != pr.InnerUDP().Src || p.UDP().Dst != pr.InnerUDP().Dst {
 		// source and destination ports do not match
 		return false
 	}
-	if pr.InnerIP().ID != p.IP().ID {
+	if pr.InnerIP().ID != p.ip.ID {
 		// the two packets do not belong to the same flow
 		return false
 	}


### PR DESCRIPTION
Go's x/net/ipv{6,4} packages provide fewer and more basic facilities for
packet handling, but their portability is better than the embedded `net`
library in dublin-traceroute. For better portability I am replacing the
ipv6 and ipv4 layers with Go's ones, while leaving UDP and ICMP handling
in the embedded net library.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>