### PR TITLE
Fixed bug： in udpv6probe.go related to rpu and spu Matches

### DIFF
--- a/go/dublintraceroute/probes/probev6/udpv6probe.go
+++ b/go/dublintraceroute/probes/probev6/udpv6probe.go
@@ -111,7 +111,7 @@ func (pr ProbeResponseUDPv6) Matches(pi probes.Probe) bool {
 		// this is not our packet
 		return false
 	}
-	if pr.InnerIPv6().PayloadLen != len(p.Payload)+inet.UDPHeaderLen {
+	if pr.InnerIPv6().PayloadLen != len(p.Payload) {
 		// different payload length, not our packet
 		// NOTE: here I am using pr.InnerIPv6().PayloadLen instead of len(pr.payload)
 		// because the responding hop might use an RFC4884 multi-part ICMPv6 message,

--- a/go/dublintraceroute/probes/probev6/udpv6probe.go
+++ b/go/dublintraceroute/probes/probev6/udpv6probe.go
@@ -117,6 +117,7 @@ func (pr ProbeResponseUDPv6) Matches(pi probes.Probe) bool {
 		// because the responding hop might use an RFC4884 multi-part ICMPv6 message,
 		// which has extra data at the end of time-exceeded and destination-unreachable
 		// messages
+		// NOTE: p.payload is payload of IP packet, which is the UDP packet.
 		return false
 	}
 	return true


### PR DESCRIPTION
In the Matches function of udpv6probe.go, the condition checking whether the InnerIPv6 payload length of rpu matches that of spu should be changed from:

if pr.InnerIPv6().PayloadLen != len(p.Payload) + inet.UDPHeaderLen

to:
if pr.InnerIPv6().PayloadLen != len(p.Payload)

because p.Payload represents the length of the UDP packet of spu, not the length of the UDP packet's payload.