### PR TITLE
Fix several crashes in the C++ implementation

### DIFF
--- a/src/dublin_traceroute.cc
+++ b/src/dublin_traceroute.cc
@@ -16,6 +16,7 @@
 #include <vector>
 #include <sstream>
 #include <chrono>
+#include <atomic>
 #include <functional>
 #include <unistd.h>
 #include <sys/types.h>
@@ -112,8 +113,12 @@ const void DublinTraceroute::validate_arguments() {
  * \returns an instance of TracerouteResults
  */
 std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
-	// avoid running multiple traceroutes
-	if (mutex_tracerouting.try_lock() == false)
+	// avoid running multiple traceroutes. Hold the lock via a unique_lock so it
+	// is released on every exit path, including when an exception is thrown
+	// (the previous manual unlock() was skipped on error, leaving the mutex
+	// locked and deadlocking the destructor).
+	std::unique_lock<std::mutex> tracerouting_lock(mutex_tracerouting, std::try_to_lock);
+	if (!tracerouting_lock.owns_lock())
 		throw DublinTracerouteInProgressException("Traceroute already in progress");
 
 	validate_arguments();
@@ -145,11 +150,15 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 	int ts_flag = 1;
 	int ret;
 	if ((ret = setsockopt(sock, SOL_SOCKET, SO_TIMESTAMP, (int *)&ts_flag, sizeof(ts_flag))) == -1) {
+		close(sock);
 		throw std::runtime_error(strerror(errno));
 	}
+	// Flag used to ask the listener thread to stop early (set on the error
+	// path so we never destroy a still-running, joinable std::thread).
+	std::atomic<bool> stop_listener(false);
 	std::thread listener_thread(
 		[&]() {
-			size_t received;
+			ssize_t received;
 			char buf[512];
 			struct msghdr msg;
 			memset(&msg, 0, sizeof(msg));
@@ -158,10 +167,14 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 			iov[0].iov_len = sizeof(buf);
 			msg.msg_iov = iov;
 			msg.msg_iovlen = sizeof(iov) / sizeof(struct iovec);
-			struct csmghdr *cmsg;
-			msg.msg_control = cmsg;
-			msg.msg_controllen = 0;
-			while (std::chrono::steady_clock::now() <= deadline) {
+			// control buffer to receive the SO_TIMESTAMP ancillary data.
+			// This was previously an uninitialized pointer with a zero-length
+			// control buffer, which left msg_control pointing at garbage and
+			// prevented kernel timestamps from being delivered.
+			char cmsgbuf[CMSG_SPACE(sizeof(struct timeval))];
+			msg.msg_control = cmsgbuf;
+			msg.msg_controllen = sizeof(cmsgbuf);
+			while (!stop_listener && std::chrono::steady_clock::now() <= deadline) {
 				received = recvmsg(sock, &msg, MSG_DONTWAIT);
 				if (received == -1) {
 					if (errno != EAGAIN && errno != EWOULDBLOCK) {
@@ -193,6 +206,20 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 			close(sock);
 		}
 	);
+
+	// Ensure the listener thread is always stopped and joined before this
+	// function returns, including when sending the probes throws. Destroying a
+	// joinable std::thread calls std::terminate(), which previously aborted the
+	// whole process on any probe send/setup failure (e.g. no route to host).
+	struct ListenerGuard {
+		std::thread &thread;
+		std::atomic<bool> &stop;
+		~ListenerGuard() {
+			stop = true;
+			if (thread.joinable())
+				thread.join();
+		}
+	} listener_guard{listener_thread, stop_listener};
 
 	std::shared_ptr<flow_map_t> flows(new flow_map_t);
 
@@ -263,8 +290,6 @@ std::shared_ptr<TracerouteResults> DublinTraceroute::traceroute() {
 	if (!no_dns()) {
 		match_hostnames(*results, flows);
 	}
-
-	mutex_tracerouting.unlock();
 
 	return std::make_shared<TracerouteResults>(*results);
 }

--- a/src/hop.cc
+++ b/src/hop.cc
@@ -245,8 +245,8 @@ Json::Value Hop::to_json() {
 
 					// if MPLS was encountered, also add parsed extension
 					if (ext_class == ICMP_EXTENSION_MPLS_CLASS && ext_type == ICMP_EXTENSION_MPLS_TYPE) {
-						// FIXME here I am assuming that size is always a multiple of 4
-						for (unsigned int idx = 0; idx < payload.size(); idx += 4) {
+						// each MPLS label stack entry is 4 bytes; require a full entry to avoid OOB reads
+						for (unsigned int idx = 0; idx + 4 <= payload.size(); idx += 4) {
 							unsigned int label = (payload[idx] << 12) + (payload[idx + 1] << 4) + (payload[idx + 2] >> 4);
 							unsigned int experimental = (payload[idx + 2] & 0x0f) >> 1;
 							unsigned int bottom_of_stack = payload[idx + 2] & 0x01;

--- a/src/traceroute_results.cc
+++ b/src/traceroute_results.cc
@@ -161,8 +161,11 @@ void TracerouteResults::show(std::ostream &stream) {
 							auto &payload = extension.payload();
 							if (ext_class == ICMP_EXTENSION_MPLS_CLASS && ext_type == ICMP_EXTENSION_MPLS_TYPE) {
 								// expecting size to be a multiple of 4 in valid MPLS label stacks
-								unsigned int num_labels = (extension.size() - 4) / 4;
-								for (unsigned int idx = 0; idx < payload.size() ; idx += 4) {
+								// each MPLS label stack entry is 4 bytes; require a
+								// full entry to be present before reading it, so a
+								// malformed (non-multiple-of-4) payload cannot
+								// cause an out-of-bounds read.
+								for (unsigned int idx = 0; idx + 4 <= payload.size(); idx += 4) {
 									unsigned int label = (payload[idx + 0] << 12) + (payload[idx + 1] << 4) + (payload[idx + 2] >> 4);
 									unsigned int experimental = (payload[idx + 2] & 0x0f) >> 1;
 									unsigned int bottom_of_stack = payload[idx + 2] & 0x01;
@@ -187,7 +190,6 @@ void TracerouteResults::show(std::ostream &stream) {
 				 * responding, the detected NAT could have been
 				 * started before
 				 */
-				auto inner_ip = hop.received()->rfind_pdu<Tins::RawPDU>().to<Tins::IP>();
 				stream << ", NAT ID: " << hop.nat_id();
 				if (hopnum > 1 && hop.nat_id() != prev_nat_id)
 					stream << " (NAT detected)";

--- a/src/udpv4probe.cc
+++ b/src/udpv4probe.cc
@@ -43,9 +43,15 @@ Tins::IP* UDPv4Probe::forge() {
 
 	payload[5] = ((unsigned char *)&identifier)[0];
 	payload[6] = ((unsigned char *)&identifier)[1];
+	/* Build the RawPDU from an explicit [begin, end) range. Passing a bare
+	 * `char *` would select the std::string constructor, which reads up to
+	 * the first NUL byte: since the identifier bytes are usually non-zero,
+	 * there is no terminator and the construction reads past the end of the
+	 * `payload` buffer (stack buffer over-read).
+	 */
 	Tins::IP *packet = new Tins::IP(remote_addr_, local_addr_) /
 		Tins::UDP(remote_port_, local_port_) /
-		Tins::RawPDU((char *)payload);
+		Tins::RawPDU(payload, payload + sizeof(payload));
 	packet->ttl(ttl_);
 	packet->flags(Tins::IP::DONT_FRAGMENT);
 


### PR DESCRIPTION
- udpv4probe.cc: build the probe RawPDU from an explicit [begin, end) byte range instead of `RawPDU((char *)payload)`. The bare char* selected the std::string(const char*) constructor, which runs strlen over the buffer; since the trailing identifier bytes are usually non-zero there is no NUL terminator, so it read past the end of the stack array (confirmed stack-buffer-overflow under AddressSanitizer).

- dublin_traceroute.cc: always stop and join the ICMP listener thread before traceroute() returns. Previously any exception thrown after the thread was created (e.g. a failed probe send / no route to host) unwound past a still joinable std::thread, calling std::terminate() and aborting the process. A ListenerGuard RAII object now joins the thread on every exit path, and an atomic stop flag lets the error path tear down promptly.

- dublin_traceroute.cc: hold mutex_tracerouting with a std::unique_lock (try_to_lock) instead of a manual try_lock()/unlock(). The manual unlock() was skipped on the exception path, leaving the mutex locked and deadlocking the destructor; also close(sock) before throwing on setsockopt failure.

- dublin_traceroute.cc: replace the uninitialized msg_control pointer with a properly sized control buffer so recvmsg no longer references garbage (and SO_TIMESTAMP kernel timestamps now actually work), and use ssize_t for the recvmsg return value.

- hop.cc, traceroute_results.cc: require a full 4-byte entry before parsing an MPLS label stack entry, so a malformed (non-multiple-of-4) ICMP MPLS extension from the network cannot cause an out-of-bounds vector read. Also remove dead code in TracerouteResults::show() that re-parsed the inner IP and could throw an uncaught exception.