### PR TITLE
[go] Build routest only on Linux

### DIFF
--- a/go/dublintraceroute/cmd/routest/main.go
+++ b/go/dublintraceroute/cmd/routest/main.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /* SPDX-License-Identifier: BSD-2-Clause */
 
 package main

--- a/go/dublintraceroute/cmd/routest/reply.go
+++ b/go/dublintraceroute/cmd/routest/reply.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /* SPDX-License-Identifier: BSD-2-Clause */
 
 package main

--- a/go/dublintraceroute/cmd/routest/send.go
+++ b/go/dublintraceroute/cmd/routest/send.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /* SPDX-License-Identifier: BSD-2-Clause */
 
 package main


### PR DESCRIPTION
routest can only build on Linux because of NFQUEUE and BindToDevice, so adding a build tag