### PR TITLE
[go] Clamp negative RTT to avoid a uint64 underflow

### DIFF
--- a/go/dublintraceroute/probes/probev4/udpv4.go
+++ b/go/dublintraceroute/probes/probev4/udpv4.go
@@ -327,7 +327,14 @@ func (d UDPv4) Match(sent []probes.Probe, received []probes.ProbeResponse) resul
 			probe.Flowhash = flowhash
 			probe.IsLast = bytes.Equal(rpu.Header.Src.To4(), d.Target.To4()) || isPortUnreachable
 			probe.Name = rpu.Header.Src.String() // TODO compute this field
-			probe.RttUsec = uint64(rpu.Timestamp.Sub(spu.Timestamp)) / 1000
+			rtt := rpu.Timestamp.Sub(spu.Timestamp)
+			if rtt < 0 {
+				// On fast paths (e.g. the loopback used by the integration
+				// tests) the listener can timestamp the reply before the
+				// send time is recorded, which would underflow the uint64.
+				rtt = 0
+			}
+			probe.RttUsec = uint64(rtt) / 1000
 			probe.NATID = NATID
 			probe.ZeroTTLForwardingBug = (rpu.InnerIP().TTL == 0)
 			probe.Received = &results.Packet{

--- a/go/dublintraceroute/probes/probev6/udpv6.go
+++ b/go/dublintraceroute/probes/probev6/udpv6.go
@@ -312,7 +312,14 @@ func (d UDPv6) Match(sent []probes.Probe, received []probes.ProbeResponse) resul
 			// TODO check if To16() is the right thing to do here
 			probe.IsLast = bytes.Equal(rpu.Addr.To16(), d.Target.To16())
 			probe.Name = rpu.Addr.String()
-			probe.RttUsec = uint64(rpu.Timestamp.Sub(spu.Timestamp)) / 1000
+			rtt := rpu.Timestamp.Sub(spu.Timestamp)
+			if rtt < 0 {
+				// On fast paths (e.g. the loopback used by the integration
+				// tests) the listener can timestamp the reply before the
+				// send time is recorded, which would underflow the uint64.
+				rtt = 0
+			}
+			probe.RttUsec = uint64(rtt) / 1000
 			probe.ZeroTTLForwardingBug = (rpu.InnerIPv6().HopLimit == 0)
 			probe.Received = &results.Packet{
 				Timestamp: results.UnixUsec(rpu.Timestamp),


### PR DESCRIPTION
On fast paths (e.g. routest loopback) the reply can be timestamped before the send, making received-sent negative; clamp it to zero before the uint64 conversion in the v4 and v6 probes.